### PR TITLE
Stick to ECMA 2015 syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,5 +5,10 @@
   "extends": [
     "bloq",
     "bloq/experimental"
-  ]
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": false
+    }
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ function createProxy (options) {
     onReq,
     onRes,
     onErr
-  } = { ...onDefaults, ...options }
+  } = Object.assign({}, onDefaults, options)
 
   const proxy = httpProxy.createProxyServer({})
 

--- a/test/src.index.spec.js
+++ b/test/src.index.spec.js
@@ -42,7 +42,7 @@ describe('Proxy', function () {
         res.body.should.deep.equal({
           method: 'POST',
           path: '/path',
-          req: { ...reqBody }
+          req: Object.assign({}, reqBody)
         })
       })
       .finally(function () {
@@ -67,10 +67,10 @@ describe('Proxy', function () {
     const testProxy = createProxy({
       target: `http://localhost:${testServer.address().port}`,
       onReq (req) {
-        return Object.assign(req, { body: { ...req.body, ...reqUpd } })
+        return Object.assign(req, { body: Object.assign({}, req.body, reqUpd) })
       },
       onRes (body) {
-        return { ...body, ...resUpd }
+        return Object.assign({}, body, resUpd)
       }
     })
 
@@ -82,10 +82,10 @@ describe('Proxy', function () {
       timeout: 500
     })
       .then(function (res) {
-        res.body.should.deep.equal({
-          req: { ...reqBody, ...reqUpd },
-          ...resUpd
-        })
+        res.body.should.deep.equal(Object.assign(
+          { req: Object.assign({}, reqBody, reqUpd) },
+          resUpd
+        ))
       })
       .finally(function () {
         testProxy.close()


### PR DESCRIPTION
This change enables backwards compatibility with Node.JS versions 6 and up.

Current code uses object spread which is supported in version 8 and above.